### PR TITLE
feat: allow to run as non-root

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: athens-proxy
 version: 0.5.9
-appVersion: v0.11.0
+appVersion: v0.12.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png
 keywords:

--- a/charts/athens-proxy/templates/_helpers.tpl
+++ b/charts/athens-proxy/templates/_helpers.tpl
@@ -14,3 +14,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Determine the home directory of the current user.
+*/}}
+{{- define "home" -}}
+{{- if not .Values.image.runAsNonRoot -}}
+/root
+{{- else -}}
+/home/athens
+{{- end -}}
+{{- end -}}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -46,14 +46,20 @@ spec:
           command:
             - sh
             - -c
-          args: ["cp /root/.ssh/id_rsa* /ssh-keys && chmod 400 /ssh-keys/*"]
+          args: ["cp {{ template "home" . }}/.ssh/id_rsa* /ssh-keys && chmod 400 /ssh-keys/*"]
           volumeMounts:
           - name: ssh-keys
             mountPath: /ssh-keys
+          {{- $dot := . -}}
           {{- range $server := .Values.sshGitServers }}
           - name: ssh-git-servers-secret
-            mountPath: /root/.ssh/id_rsa-{{ $server.host }}
+            mountPath: {{ template "home" $dot }}/.ssh/id_rsa-{{ $server.host }}
             subPath: id_rsa-{{ $server.host }}
+          {{- end }}
+          {{- if .Values.image.runAsNonRoot }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           {{- end }}
       {{- end }}
       containers:
@@ -187,10 +193,10 @@ spec:
         {{- end }}
         {{- if .Values.sshGitServers }}
         - name: ssh-git-servers-config
-          mountPath: /root/.ssh/config
+          mountPath: {{ template "home" . }}/.ssh/config
           subPath: ssh_config
         - name: ssh-git-servers-config
-          mountPath: /root/.gitconfig
+          mountPath: {{ template "home" . }}/.gitconfig
           subPath: git_config
         - name: ssh-keys
           mountPath: /ssh-keys
@@ -199,6 +205,11 @@ spec:
         - name: gitconfig
           mountPath: "/etc/gitconfig"
           subPath: "gitconfig"
+        {{- end }}
+        {{- if .Values.image.runAsNonRoot }}
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
         {{- end }}
       {{- with .Values.resources }}
         resources:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -15,6 +15,9 @@ image:
   pullSecrets: []
   #  - name: name-of-secret
 
+  ## Determine if the image should run as root or user `athens`
+  runAsNonRoot: false
+
 livenessProbe:
   failureThreshold: 3
   periodSeconds: 10

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -3,7 +3,7 @@ image:
   registry: docker.io
   repository: gomods/athens
   # Override the chart appVersion and use a specific tag
-  # tag: v0.11.0
+  # tag: v0.12.0
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
This PR adds support for non-root containers to the helm chart.

A new bool value `image.runAsNonRoot` (default: false) was added, and when set to true, will add a `securityContext` to use the user and group `1000` as well as switching the home directory from `/root` to `/home/athens`.

This PR is dependent on the [non-root PR](https://github.com/gomods/athens/pull/1843) being merged and a new athens release.