### PR TITLE
fix: use integer values for hpa, refactor for argocd

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.6.0
+version: 0.6.1
 appVersion: v0.12.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/hpa.yaml
+++ b/charts/athens-proxy/templates/hpa.yaml
@@ -22,10 +22,10 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-  {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
-        name: cpu
+        name: memory
         {{- if eq $apiVersion "autoscaling/v2beta1" }}
         targetAverageUtilization: {{ . }}
         {{- else }}
@@ -34,10 +34,10 @@ spec:
           type: Utilization
         {{- end }}
   {{- end }}
-  {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
-        name: memory
+        name: cpu
         {{- if eq $apiVersion "autoscaling/v2beta1" }}
         targetAverageUtilization: {{ . }}
         {{- else }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -198,8 +198,8 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 3
-  targetCPUUtilizationPercentage: 80%
-  targetMemoryUtilizationPercentage: 80%
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
   apiVersionOverride: ""
   # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
   behavior: {}


### PR DESCRIPTION
Autoscaling values must be integers, percents are not working.
We deploy athens proxy through ArgoCD. ArgoCD always shows the difference and wants to change memory with cpu utilization specification. In fact, it is the same, so let's change their order.