### PR TITLE
chore: add dependabot for up-to-date github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: update-github-action
+      include: scope
+    open-pull-requests-limit: 2
+    target-branch: main


### PR DESCRIPTION
closes https://github.com/gomods/athens-charts/issues/17

solution is taken from https://github.com/gomods/athens/pull/1835/files