### PR TITLE
Added possibility to define externally added secrets (e.g. created by…

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.6.1
+version: 0.7.0
 appVersion: v0.12.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -52,9 +52,15 @@ spec:
             mountPath: /ssh-keys
           {{- $dot := . -}}
           {{- range $server := .Values.sshGitServers }}
+          {{- if $server.existingSecret }}
+          - name: ssh-git-servers-secret-{{ $server.host | replace "." "-" }}
+            mountPath: "{{ template "home" $dot }}/.ssh/id_rsa-{{ $server.host }}"
+            subPath: {{ $server.existingSecret.subPath | quote }}
+          {{- else }}
           - name: ssh-git-servers-secret
             mountPath: {{ template "home" $dot }}/.ssh/id_rsa-{{ $server.host }}
             subPath: id_rsa-{{ $server.host }}
+          {{- end }}
           {{- end }}
           {{- if .Values.image.runAsNonRoot }}
           securityContext:
@@ -223,6 +229,13 @@ spec:
           mountPath: "/etc/gitconfig"
           subPath: "gitconfig"
         {{- end }}
+        {{- range $server := .Values.sshGitServers }}
+        {{- if $server.existingSecret }}
+        - name: ssh-git-servers-secret-{{ $server.host | replace "." "-" }}
+          mountPath: "/root/.ssh/id_rsa-{{ $server.host }}"
+          subPath: {{ $server.existingSecret.subPath | quote }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.image.runAsNonRoot }}
         securityContext:
           runAsUser: 1000
@@ -259,6 +272,13 @@ spec:
       - name: ssh-git-servers-secret
         secret:
           secretName: {{ template "fullname" . }}-ssh-git-servers
+      {{- range $server := .Values.sshGitServers }}
+      {{- if $server.existingSecret }}
+      - name: ssh-git-servers-secret-{{ $server.host | replace "." "-" }}
+        secret:
+          secretName: {{ $server.existingSecret.name | quote }}
+      {{- end }}
+      {{- end }}
       {{- end }}
       {{- if .Values.gitconfig.enabled }}
       - name: gitconfig

--- a/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
@@ -6,6 +6,8 @@ metadata:
 type: Opaque
 data:
 {{- range $server := .Values.sshGitServers }}
+  {{- if (not $server.existingSecret) -}}
   id_rsa-{{ $server.host }}: {{ $server.privateKey | b64enc | quote }}
+  {{- end -}}
 {{- end }}
 {{- end -}}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -159,6 +159,10 @@ sshGitServers: {}
   #     -----END RSA PRIVATE KEY-----
   ## ssh port
   #   port: 22
+  ## ssh private key from the existing secret (to be added separately in "Secret" Resource)
+  #   existingSecret:
+  #     name: ssh-keys
+  #     subPath: secret.id_rsa
 
 goGetWorkers: 3
 


### PR DESCRIPTION
… a secret manager)

Fixes #37

This adds possibility to say that the secret is provided in another resource:
```
athens-proxy:
...
  sshGitServers:
    - host: github.repository
 ...
      existingSecret:
        name: ssh-keys
        subPath: "teamcity-app-id_rsa"
```