### PR TITLE
Add default SSH port

### DIFF
--- a/charts/athens-proxy/templates/config-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/config-ssh-git-servers.yaml
@@ -14,7 +14,7 @@ data:
     Host {{ $server.host }}
       Hostname {{ $server.host }}
       User {{ $server.user }}
-      Port {{ $server.port }}
+      Port {{ $server.port | default 22 }}
       StrictHostKeyChecking no
       IdentityFile /ssh-keys/id_rsa-{{ $server.host }}
     {{- end }}


### PR DESCRIPTION
22 is the default SSH port and I reckon can be used in most cases.
I just thought that we could simplify a little bit configuration by removing parameter that is always the same :)