### PR TITLE
Add new standard labels and allow custom labels

### DIFF
--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -6,3 +6,7 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+jaeger:
+  enabled: true
+extraLabels:
+  athensIs: "awesome"

--- a/charts/athens-proxy/templates/_helpers.tpl
+++ b/charts/athens-proxy/templates/_helpers.tpl
@@ -16,6 +16,40 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Common labels used by all resources in their meta fields.
+Includes existing labels for passivity, new standard labels, and user-defined extra labels.
+https://helm.sh/docs/chart_best_practices/labels/
+https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+*/}}
+{{- define "athens.metaLabels" -}}
+{{- /* Allow an app suffix name to be passed in to append to the fullname */}}
+{{- $defaultAppName := include "fullname" . }}
+{{- $appName := printf "%s%s" $defaultAppName (default "" .appSuffix) }}
+{{- /* Existing Legacy labels for passivity */}}
+app: {{ $appName }}
+chart: {{ template "athens.chart" . }}
+release: "{{ .Release.Name }}"
+heritage: "{{ .Release.Service }}"
+{{- /* New Standard labels */}}
+app.kubernetes.io/name: {{ $appName }}
+helm.sh/chart: {{ template "athens.chart" . }}
+app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+app.kubernetes.io/instance: "{{ .Release.Name }}"
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- /* Include user defined labels */}}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end -}}
+{{- end }}
+
+{{/*
+A common helper for creating the full chart name and version as used by the chart label.
+*/}}
+{{- define "athens.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Determine the home directory of the current user.
 */}}
 {{- define "home" -}}

--- a/charts/athens-proxy/templates/config-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/config-ssh-git-servers.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-ssh-git-servers
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
 data:
   ssh_config: |
     {{- range $server := .Values.sshGitServers }}

--- a/charts/athens-proxy/templates/config-upstream.yaml
+++ b/charts/athens-proxy/templates/config-upstream.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-upstream
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
 data:
   FilterForUpstreamProxy: |-
     # FilterFile for fetching modules directly from upstream proxy

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if .Values.strategy }}
@@ -23,9 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        release: "{{ .Release.Name }}"
+        {{- include "athens.metaLabels" . | nindent 8 }}
       annotations:
         checksum/upstream: {{ include (print $.Template.BasePath "/config-upstream.yaml") . | sha256sum }}
         checksum/ssh-config: {{ include (print $.Template.BasePath "/config-ssh-git-servers.yaml") . | sha256sum }}

--- a/charts/athens-proxy/templates/hpa.yaml
+++ b/charts/athens-proxy/templates/hpa.yaml
@@ -10,10 +10,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/athens-proxy/templates/ingress.yaml
+++ b/charts/athens-proxy/templates/ingress.yaml
@@ -17,10 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "athens.metaLabels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/athens-proxy/templates/jaeger-deploy.yaml
+++ b/charts/athens-proxy/templates/jaeger-deploy.yaml
@@ -4,10 +4,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}-jaeger
   labels:
-    app: {{ template "fullname" . }}-jaeger
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" (dict "appSuffix" "-jaeger" "Values" .Values "Release" .Release "Chart" .Chart) | nindent 4 }}
 spec:
   replicas: 1
   selector:

--- a/charts/athens-proxy/templates/jaeger-svc.yaml
+++ b/charts/athens-proxy/templates/jaeger-svc.yaml
@@ -4,10 +4,7 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-jaeger
   labels:
-    app: {{ template "fullname" . }}-jaeger
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" (dict "appSuffix" "-jaeger" "Values" .Values "Release" .Release "Chart" .Chart) | nindent 4 }}
 spec:
   type: {{ .Values.jaeger.type }}
   ports:

--- a/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
@@ -3,6 +3,8 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-ssh-git-servers
+  labels:
+    {{- include "athens.metaLabels" . | nindent 4 }}
 type: Opaque
 data:
 {{- range $server := .Values.sshGitServers }}

--- a/charts/athens-proxy/templates/secret.yaml
+++ b/charts/athens-proxy/templates/secret.yaml
@@ -2,6 +2,8 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-secret
+  labels:
+    {{- include "athens.metaLabels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.storage.mongo.url }}

--- a/charts/athens-proxy/templates/service-account.yaml
+++ b/charts/athens-proxy/templates/service-account.yaml
@@ -4,10 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/athens-proxy/templates/service-monitor.yaml
+++ b/charts/athens-proxy/templates/service-monitor.yaml
@@ -4,10 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
     prometheus: default
   {{- with .Values.service.annotations }}
   annotations:

--- a/charts/athens-proxy/templates/service-scrape.yaml
+++ b/charts/athens-proxy/templates/service-scrape.yaml
@@ -4,10 +4,7 @@ apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
     prometheus: default
   {{- with .Values.service.annotations }}
   annotations:

--- a/charts/athens-proxy/templates/service.yaml
+++ b/charts/athens-proxy/templates/service.yaml
@@ -7,10 +7,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/athens-proxy/templates/storage-pvc.yaml
+++ b/charts/athens-proxy/templates/storage-pvc.yaml
@@ -4,10 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ template "fullname" . }}-storage
   labels:
-    app: {{ template "fullname" . }}-storage
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "athens.metaLabels" (dict "appSuffix" "-storage" "Values" .Values "Release" .Release "Chart" .Chart) | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.storage.disk.persistence.accessMode | quote }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -101,6 +101,9 @@ configEnvVars: {}
 # Extra annotations to be added to the athens pods
 annotations: {}
 
+# Extra labels to be added to all resources
+extraLabels: {}
+
 # HTTP basic auth
 basicAuth:
   enabled: false


### PR DESCRIPTION
Resolves #44 

## Why

This chart appears to have the standard labels used with helm 2. This adds in the new helm 3 standard labels and also allows the user to pass in additional labels that will get applied to all resources. 

## How

- Create a template helper that creates metadata labels that can be reused by multiple resource templates
- Include the existing labels in this helper for passivity
- default to use the fullName value for the name labels but allow an optional `appSuffix` to be passed in for passivity for the jaeger and storage usecases
- include this new helper in some resources that were missing the common labels
- add a helm value to pass in an object of custom labels which is a common helm convention
- enable jaeger and pass custom labels in CI to exercise more code paths

## Validation

Run `helm template charts/athens-proxy --set extraLabels.athensIs=awesome --set jaeger.enabled=true` against main and this branch and diff them

<details>
<summary>Diff</summary>

```
7a8
>
9c10
<     chart: "athens-proxy-0.7.0"
---
>     chart: athens-proxy-0.7.0
11a13,18
>     app.kubernetes.io/name: release-name-athens-proxy
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
17a25,36
>   labels:
>
>     app: release-name-athens-proxy
>     chart: athens-proxy-0.7.0
>     release: "release-name"
>     heritage: "Helm"
>     app.kubernetes.io/name: release-name-athens-proxy
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
26a46
>
28c48
<     chart: "athens-proxy-0.7.0"
---
>     chart: athens-proxy-0.7.0
30a51,56
>     app.kubernetes.io/name: release-name-athens-proxy-jaeger
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
67a94
>
69c96
<     chart: "athens-proxy-0.7.0"
---
>     chart: athens-proxy-0.7.0
71a99,104
>     app.kubernetes.io/name: release-name-athens-proxy
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
88a122
>
90c124
<     chart: "athens-proxy-0.7.0"
---
>     chart: athens-proxy-0.7.0
92a127,132
>     app.kubernetes.io/name: release-name-athens-proxy
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
101a142
>
103c144
<         chart: "athens-proxy-0.7.0"
---
>         chart: athens-proxy-0.7.0
104a146,152
>         heritage: "Helm"
>         app.kubernetes.io/name: release-name-athens-proxy
>         helm.sh/chart: athens-proxy-0.7.0
>         app.kubernetes.io/managed-by: "Helm"
>         app.kubernetes.io/instance: "release-name"
>         app.kubernetes.io/version: "v0.12.0"
>         athensIs: awesome
152a201
>
154c203
<     chart: "athens-proxy-0.7.0"
---
>     chart: athens-proxy-0.7.0
156a206,211
>     app.kubernetes.io/name: release-name-athens-proxy-jaeger
>     helm.sh/chart: athens-proxy-0.7.0
>     app.kubernetes.io/managed-by: "Helm"
>     app.kubernetes.io/instance: "release-name"
>     app.kubernetes.io/version: "v0.12.0"
>     athensIs: awesome
```
</details>

<details>
<summary>Example Output from template</summary>

```
---
# Source: athens-proxy/templates/service-account.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-athens-proxy
  labels:
    
    app: release-name-athens-proxy
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
---
# Source: athens-proxy/templates/secret.yaml
kind: Secret
apiVersion: v1
metadata:
  name: release-name-athens-proxy-secret
  labels:
    
    app: release-name-athens-proxy
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
type: Opaque
data:
---
# Source: athens-proxy/templates/jaeger-svc.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-athens-proxy-jaeger
  labels:
    
    app: release-name-athens-proxy-jaeger
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy-jaeger
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
spec:
  type: ClusterIP
  ports:
    - name: jaeger-collector-http
      port: 14268
      protocol: TCP
      targetPort: 14268
    - name: jaeger-zipkin-thrift
      port: 5775
      protocol: UDP
      targetPort: 5775
    - name: jaeger-compact
      port: 6831
      protocol: UDP
      targetPort: 6831
    - name: jaeger-binary
      port: 6832
      protocol: UDP
      targetPort: 6832
    - name: jaeger-configs
      port: 5778
      protocol: TCP
      targetPort: 5778
    - name: jaeger-query-http
      port: 16686
      protocol: TCP
      targetPort: 16686
  selector:
    app: release-name-athens-proxy-jaeger
    release: "release-name"
---
# Source: athens-proxy/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-athens-proxy
  labels:
    
    app: release-name-athens-proxy
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
spec:
  type: ClusterIP
  ports:
  - name: http
    port: 80
    targetPort: 3000
    protocol: TCP
  selector:
    app: release-name-athens-proxy
    release: "release-name"
---
# Source: athens-proxy/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-athens-proxy
  labels:
    
    app: release-name-athens-proxy
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
spec:
  replicas: 1
  selector:
    matchLabels:
      app: release-name-athens-proxy
      release: "release-name"
  template:
    metadata:
      labels:
        
        app: release-name-athens-proxy
        chart: athens-proxy-0.7.0
        release: "release-name"
        heritage: "Helm"
        app.kubernetes.io/name: release-name-athens-proxy
        helm.sh/chart: athens-proxy-0.7.0
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "release-name"
        app.kubernetes.io/version: "v0.12.0"
        athensIs: awesome
      annotations:
        checksum/upstream: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
        checksum/ssh-config: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
        checksum/ssh-secret: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
    spec:
      serviceAccount: release-name-athens-proxy
      containers:
      - name: release-name-athens-proxy
        image: "docker.io/gomods/athens:v0.12.0"
        imagePullPolicy: "IfNotPresent"
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: "/healthz"
            port: 3000
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        readinessProbe:
          httpGet:
            path: "/readyz"
            port: 3000
        env:
        - name: ATHENS_GOGET_WORKERS
          value: "3"
        - name: ATHENS_STORAGE_TYPE
          value: "disk"
        - name: ATHENS_DISK_STORAGE_ROOT
          value: "/var/lib/athens"
        - name: ATHENS_TRACE_EXPORTER_URL
          value: "SET THIS ON THE COMMAND LINE"
        - name: ATHENS_TRACE_EXPORTER
          value: "jaeger"
        ports:
        - containerPort: 3000
        volumeMounts:
        - name: storage-volume
          mountPath: "/var/lib/athens"
      volumes:
      - name: storage-volume
        emptyDir: {}
---
# Source: athens-proxy/templates/jaeger-deploy.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-athens-proxy-jaeger
  labels:
    
    app: release-name-athens-proxy-jaeger
    chart: athens-proxy-0.7.0
    release: "release-name"
    heritage: "Helm"
    app.kubernetes.io/name: release-name-athens-proxy-jaeger
    helm.sh/chart: athens-proxy-0.7.0
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
    app.kubernetes.io/version: "v0.12.0"
    athensIs: awesome
spec:
  replicas: 1
  selector:
    matchLabels:
      app: release-name-athens-proxy-jaeger
      release: "release-name"
  template:
    metadata:
      labels:
        app: release-name-athens-proxy-jaeger
        chart: "athens-proxy-0.7.0"
        release: "release-name"
    spec:
      containers:
        - env:
            - name: COLLECTOR_ZIPKIN_HTTP_PORT
              value: "9441"
          image: "jaegertracing/all-in-one:latest"
          name: release-name-athens-proxy-jaeger
          ports:
            - containerPort: 14268
              protocol: TCP
            - containerPort: 5775
              protocol: UDP
            - containerPort: 6831
              protocol: UDP
            - containerPort: 6832
              protocol: UDP
            - containerPort: 5778
              protocol: TCP
            - containerPort: 16686
              protocol: TCP
            - containerPort: 9411
              protocol: TCP
---
# Source: athens-proxy/templates/test/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "release-name-athens-proxy-test-connection"
  labels:
    app: release-name-athens-proxy
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['release-name-athens-proxy:80']
  restartPolicy: Never
```
</details>