### PR TITLE
chore: enable container security contexts modifications

### DIFF
--- a/.github/workflows/ct.yaml
+++ b/.github/workflows/ct.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.7.1
+version: 0.8.0
 appVersion: v0.12.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -10,3 +10,6 @@ jaeger:
   enabled: true
 extraLabels:
   athensIs: "awesome"
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -10,6 +10,8 @@ jaeger:
   enabled: true
 extraLabels:
   athensIs: "awesome"
+image:
+  runAsNonRoot: true
 securityContext:
   allowPrivilegeEscalation: false
   runAsNonRoot: true

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -29,6 +29,11 @@ spec:
         {{- toYaml .Values.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.image.runAsNonRoot }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      {{- end }}
       serviceAccount: {{ template "fullname" . }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -57,10 +62,9 @@ spec:
             subPath: id_rsa-{{ $server.host }}
           {{- end }}
           {{- end }}
-          {{- if .Values.image.runAsNonRoot }}
+          {{- with .Values.initContainerSecurityContext }}
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.intiContainerResources }}
           resources:
@@ -235,15 +239,14 @@ spec:
           subPath: {{ $server.existingSecret.subPath | quote }}
         {{- end }}
         {{- end }}
-        {{- if .Values.image.runAsNonRoot }}
+        {{- with .Values.securityContext }}
         securityContext:
-          runAsUser: 1000
-          runAsGroup: 1000
+          {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- with .Values.resources }}
+        {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
-      {{- end }}
+        {{- end }}
       volumes:
       - name: storage-volume
       {{- if .Values.storage.disk.persistence.enabled }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -94,6 +94,16 @@ storage:
     # as GCP figures out internal authentication between products for you.
     serviceAccount: ""
 
+# Container security context configuration (see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)
+# This will override the `image.runAsNonRoot` settings in the specified container if `runAsUser` or `runAsGroup` are set
+securityContext: {}
+  # allowPrivilegeEscalation: false
+  # runAsNonRoot: true
+
+initContainerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+  # runAsNonRoot: true
+
 # Extra environment variables to be passed
 # You can add any new ones at the bottom
 configEnvVars: {}


### PR DESCRIPTION
Resolves issue: https://github.com/gomods/athens-charts/issues/49.

This PR updates the chart to enable us to override/set additional security context configuration at the container level in each of the containers in the athens-proxy deployment template. 

It moves the existing `securityContext` configuration to the `PodSecurityContext` at the pod spec level to ensure this isn't a breaking change and ensures backwards compatibility. It adds two new values in the chart `securityContext` (for the main athens container) and `initContainerSecurityContext` (for the init container, if used). This allows us to override/modify the existing configuration with additional security context configuration options in each of the containers, at the container `securityContext` level. 

See `PodSecurityContext` API reference for fields that can be set at the pod spec level (for the existing `image.runAsNonRoot` configuration): https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core. 

And see `SecurityContext` API reference for the fields that can be set at the container spec level: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core.
