### PR TITLE
chore: update to athens v0.13.1

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.9.0
-appVersion: v0.13.0
+version: 0.9.1
+appVersion: v0.13.1
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png
 keywords:


### PR DESCRIPTION
includes bug fix for `arm64`