### PR TITLE
Fix SSH Git Servers secret

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.9.1
+version: 0.9.2
 appVersion: v0.13.1
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
@@ -8,8 +8,8 @@ metadata:
 type: Opaque
 data:
 {{- range $server := .Values.sshGitServers }}
-  {{- if (not $server.existingSecret) -}}
+  {{ if (not $server.existingSecret) }}
   id_rsa-{{ $server.host }}: {{ $server.privateKey | b64enc | quote }}
-  {{- end -}}
+  {{ end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
Fixes #53 by removing the dash that trims the prefix.

Manifest generated using version 0.9.1:

```
kind: Secret
apiVersion: v1
metadata:
  name: athens-athens-proxy-ssh-git-servers
  labels:
    
    app: athens-athens-proxy
    chart: athens-proxy-0.9.1
    release: "athens"
    heritage: "Helm"
    app.kubernetes.io/name: athens-athens-proxy
    helm.sh/chart: athens-proxy-0.9.1
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "athens"
    app.kubernetes.io/version: "v0.13.1"
type: Opaque
data:id_rsa-sample.server.com: "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KUkVEQUNURUQKLS0tLS1FTkQgT1BFTlNTSCBQUklWQVRFIEtFWS0tLS0tCg=="
```

Manifest generated after the fix:
```
kind: Secret
apiVersion: v1
metadata:
  name: athens-athens-proxy-ssh-git-servers
  labels:
    
    app: athens-athens-proxy
    chart: athens-proxy-0.9.1
    release: "athens"
    heritage: "Helm"
    app.kubernetes.io/name: athens-athens-proxy
    helm.sh/chart: athens-proxy-0.9.1
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "athens"
    app.kubernetes.io/version: "v0.13.1"
type: Opaque
data:
  id_rsa-sample.server.com: "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KUkVEQUNURUQKLS0tLS1FTkQgT1BFTlNTSCBQUklWQVRFIEtFWS0tLS0tCg=="
```