### PR TITLE
Allow setting a priority class name

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.9.2
+version: 0.9.3
 appVersion: v0.13.1
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         {{- toYaml .Values.annotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.image.runAsNonRoot }}
       securityContext:
         runAsUser: 1000

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -94,6 +94,9 @@ storage:
     # as GCP figures out internal authentication between products for you.
     serviceAccount: ""
 
+## Priority class for pod scheduling (see API reference: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass)
+priorityClassName: ""
+
 # Container security context configuration (see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)
 # This will override the `image.runAsNonRoot` settings in the specified container if `runAsUser` or `runAsGroup` are set
 securityContext: {}


### PR DESCRIPTION
## Why
We run athens using this helm chart and would like to change its priority class in the cluster. 

## How

- create a new value that defaults to empty
- passively only add the priority class if specified
- include an update to the Chart.yaml to trigger a release

## Validation

```
❯ helm template charts/athens-proxy | grep priority
❯ helm template charts/athens-proxy --set priorityClassName=critical | grep priority
      priorityClassName: "critical"
```