### PR TITLE
fix: Post-upgrade tasks can only be used on self-hosted Renovate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ On Artifact Hub: https://artifacthub.io/packages/search?org=gomods
 * Create issues, create PRs, ... let's make this better together.
 * See [Contributing](CONTRIBUTING.md)
 
-### Publish new chart version
-Change the version in `Chart.yaml`. When the change is merged to main, it will trigger creating a release.
+### Publish a new chart version
+Create a PR that changes the version in `Chart.yaml`. When the change is merged to main, it will trigger creating a release.
 
 A version bump is not enforced, so changes are collected on branch `main` and only released when the version of 
 the chart is changed.
+
+To release the chart with a new Athens version, the PR that bumps the Athens image version is created automatically.
+This can be merged to `main` without impact for the current release. After this, create a PR that updates the Chart
+version to release the chart using the new Athens image version.

--- a/renovate.json
+++ b/renovate.json
@@ -14,23 +14,5 @@
       "depNameTemplate": "gomods/athens",
       "datasourceTemplate": "docker"
     }
-  ],
-  "packageRules": [
-    {
-      "matchManagers": ["regex"],
-      "postUpgradeTasks": {
-        "commands": [
-          "version=$(grep '^version:' {{{parentDir}}}/charts/athens-proxy/Chart.yaml | awk '{print $2}')",
-          "major=$(echo $version | cut -d. -f1)",
-          "minor=$(echo $version | cut -d. -f2)",
-          "patch=$(echo $version | cut -d. -f3)",
-          "minor=$(expr $minor + 1)",
-          "echo \"New version: $version\"",
-          "sed -i \"s/^version:.*/version: ${major}.${minor}.${patch}/g\" {{{parentDir}}}/charts/athens-proxy/Chart.yaml"
-        ],
-        "fileFilters": ["**/Chart.yaml"],
-        "executionMode": "branch"
-      }
-    }
   ]
 }


### PR DESCRIPTION
doc: update Readme on the release process