### PR TITLE
fix: don't specify replicas when autoscaling is enabled

### DIFF
--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
     {{- include "athens.metaLabels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- if .Values.strategy }}
   strategy:
   {{- toYaml .Values.strategy | nindent 4 }}


### PR DESCRIPTION
Horizontal Pod Autoscalers automatically change the `replicas` field based on runtime metrics of the application.

This can cause false warnings to appear for folks using GitOps tooling such as ArgoCD because the tool will indicate that the application is out-of-sync due to this field when it actually isn't.

<img width="584" alt="Screenshot 2024-04-19 at 10 50 27" src="https://github.com/gomods/athens-charts/assets/86535092/3a1d1e8a-0043-4acf-aa6a-11e7170d7483">

<img width="1423" alt="Screenshot 2024-04-19 at 10 50 43" src="https://github.com/gomods/athens-charts/assets/86535092/a9c3fd06-1e85-4c77-9888-8df574f91946">

This PR cleans up the deployment object so that it's not marked as Out-Of-Sync