### PR TITLE
fix: preprovisioned service account unable to be included in deployment

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.10.0
+version: 0.11.0
 appVersion: v0.14.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png
 keywords:
-- Golang
-- Package Management
-- Goproxy
-- Athens
+  - Golang
+  - Package Management
+  - Goproxy
+  - Athens
 home: https://github.com/gomods/athens-charts
 sources:
   - https://github.com/gomods/athens-charts
 maintainers:
-- name: rimusz
-  email: rmocius@gmail.com
-- name: arschles
-  email: aaron@ecomaz.net
-- name: DrPsychick
-  email: drpsychick@drsick.net
-- name: nrwiersma
-  email: nick@wiersma.co.za
+  - name: rimusz
+    email: rmocius@gmail.com
+  - name: arschles
+    email: aaron@ecomaz.net
+  - name: DrPsychick
+    email: drpsychick@drsick.net
+  - name: nrwiersma
+    email: nick@wiersma.co.za
 engine: gotpl

--- a/charts/athens-proxy/templates/_helpers.tpl
+++ b/charts/athens-proxy/templates/_helpers.tpl
@@ -59,3 +59,11 @@ Determine the home directory of the current user.
 /home/athens
 {{- end -}}
 {{- end -}}
+
+{{- define "serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "fullname" .) .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "fullname" . }}
   labels:
     {{- include "athens.metaLabels" . | nindent 4 }}
 spec:
@@ -17,7 +17,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: {{ include "fullname" . }}
       release: "{{ .Release.Name }}"
   template:
     metadata:
@@ -39,9 +39,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ template "fullname" . }}
-      {{- end }}
+      serviceAccount: {{ .Values.serviceAccount.name | default ( include "fullname" . ) }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
@@ -53,7 +51,7 @@ spec:
           command:
             - sh
             - -c
-          args: ["cp {{ template "home" . }}/.ssh/id_rsa* /ssh-keys && chmod 400 /ssh-keys/*"]
+          args: ["cp {{ include "home" . }}/.ssh/id_rsa* /ssh-keys && chmod 400 /ssh-keys/*"]
           volumeMounts:
           - name: ssh-keys
             mountPath: /ssh-keys
@@ -61,11 +59,11 @@ spec:
           {{- range $server := .Values.sshGitServers }}
           {{- if $server.existingSecret }}
           - name: ssh-git-servers-secret-{{ $server.host | replace "." "-" }}
-            mountPath: "{{ template "home" $dot }}/.ssh/id_rsa-{{ $server.host }}"
+            mountPath: "{{ include "home" $dot }}/.ssh/id_rsa-{{ $server.host }}"
             subPath: {{ $server.existingSecret.subPath | quote }}
           {{- else }}
           - name: ssh-git-servers-secret
-            mountPath: {{ template "home" $dot }}/.ssh/id_rsa-{{ $server.host }}
+            mountPath: {{ include "home" $dot }}/.ssh/id_rsa-{{ $server.host }}
             subPath: id_rsa-{{ $server.host }}
           {{- end }}
           {{- end }}
@@ -79,7 +77,7 @@ spec:
           {{- end }}
       {{- end }}
       containers:
-      - name: {{ template "fullname" . }}
+      - name: {{ include "fullname" . }}
         image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         livenessProbe:
@@ -109,7 +107,7 @@ spec:
         - name: ATHENS_MONGO_STORAGE_URL
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: ATHENS_MONGO_STORAGE_URL
 {{- else if eq .Values.storage.type "s3" }}
         - name: AWS_REGION
@@ -124,21 +122,21 @@ spec:
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: AWS_ACCESS_KEY_ID
         {{- end }}
         {{- if .Values.storage.s3.secretKey }}
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: AWS_SECRET_ACCESS_KEY
         {{- end }}
         {{- if .Values.storage.s3.sessionToken }}
         - name: AWS_SESSION_TOKEN
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: AWS_SESSION_TOKEN
         {{- end }}
 {{- else if eq .Values.storage.type "gcp"}}
@@ -150,7 +148,7 @@ spec:
         - name: ATHENS_STORAGE_GCP_JSON_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: ATHENS_STORAGE_GCP_JSON_KEY
         {{- end }}
 {{- else if eq .Values.storage.type "minio" }}
@@ -162,14 +160,14 @@ spec:
         - name: ATHENS_MINIO_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: ATHENS_MINIO_ACCESS_KEY_ID
         {{- end }}
         {{- if .Values.storage.minio.secretKey }}
         - name: ATHENS_MINIO_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "fullname" . }}-secret
+              name: {{ include "fullname" . }}-secret
               key: ATHENS_MINIO_SECRET_ACCESS_KEY
         {{- end }}
         {{- if .Values.storage.minio.bucket }}
@@ -226,10 +224,10 @@ spec:
         {{- end }}
         {{- if .Values.sshGitServers }}
         - name: ssh-git-servers-config
-          mountPath: {{ template "home" . }}/.ssh/config
+          mountPath: {{ include "home" . }}/.ssh/config
           subPath: ssh_config
         - name: ssh-git-servers-config
-          mountPath: {{ template "home" . }}/.gitconfig
+          mountPath: {{ include "home" . }}/.gitconfig
           subPath: git_config
         - name: ssh-keys
           mountPath: /ssh-keys
@@ -258,14 +256,14 @@ spec:
       - name: storage-volume
       {{- if .Values.storage.disk.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}-storage
+          claimName: {{ include "fullname" . }}-storage
       {{- else }}
         emptyDir: {}
       {{- end }}
       {{- if .Values.upstreamProxy.enabled }}
       - name: upstream-config
         configMap:
-          name: {{ template "fullname" . }}-upstream
+          name: {{ include "fullname" . }}-upstream
       {{- end }}
       {{- if .Values.netrc.enabled }}
       - name: netrc
@@ -277,10 +275,10 @@ spec:
         emptyDir: {}
       - name: ssh-git-servers-config
         configMap:
-          name: {{ template "fullname" . }}-ssh-git-servers
+          name: {{ include "fullname" . }}-ssh-git-servers
       - name: ssh-git-servers-secret
         secret:
-          secretName: {{ template "fullname" . }}-ssh-git-servers
+          secretName: {{ include "fullname" . }}-ssh-git-servers
       {{- range $server := .Values.sshGitServers }}
       {{- if $server.existingSecret }}
       - name: ssh-git-servers-secret-{{ $server.host | replace "." "-" }}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
       {{- end }}
-      serviceAccount: {{ .Values.serviceAccount.name | default ( include "fullname" . ) }}
+      serviceAccountName: {{ include "serviceAccountName" . | quote }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}

--- a/charts/athens-proxy/templates/service-account.yaml
+++ b/charts/athens-proxy/templates/service-account.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "fullname" . }}
   labels:
     {{- include "athens.metaLabels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -99,11 +99,13 @@ priorityClassName: ""
 
 # Container security context configuration (see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)
 # This will override the `image.runAsNonRoot` settings in the specified container if `runAsUser` or `runAsGroup` are set
-securityContext: {}
+securityContext:
+  {}
   # allowPrivilegeEscalation: false
   # runAsNonRoot: true
 
-initContainerSecurityContext: {}
+initContainerSecurityContext:
+  {}
   # allowPrivilegeEscalation: false
   # runAsNonRoot: true
 
@@ -160,7 +162,8 @@ jaeger:
   # for example, you need to run 'helm install --set jaeger.url=myurl ...'
   url: "SET THIS ON THE COMMAND LINE"
 
-sshGitServers: {}
+sshGitServers:
+  {}
   ## Private git servers over ssh
   ## to enable uncomment lines with single hash below
   ## hostname of the git server
@@ -198,6 +201,7 @@ metrics:
 serviceAccount:
   create: true
   annotations: {}
+  # name: "athens-proxy"
 
 nodeSelector: {}
 
@@ -230,7 +234,8 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
   apiVersionOverride: ""
   # This is only available on HPA apiVersion `autoscaling/v2beta2` and newer
-  behavior: {}
+  behavior:
+    {}
     # scaleDown:
     #  stabilizationWindowSeconds: 300
     #  policies:


### PR DESCRIPTION
#71 excludes serviceAccounts in the deployment template entirely if `serviceAccount.enabled` is set to false, meaning it defaults to "default" for the deployment. Previously, we could create a service account that was named identical to `fullname`, i.e., either the release name or an override via values, and have that SA be used for the pod.

This PR re-adds the ability to use service accounts in the deployment *without* creating one, and also extends upon the pre-#71 behavior of allowing you to set the name of the service account to use via `serviceAccount.name`. The property is not set in the chart's default values, and defaults to the `fullname` behavior of < v0.9.4.

Additionally, we also swapped out a bunch of "templates" for "includes", as per https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-include-function.