### PR TITLE
#75: sshGitServers is a list not a dict

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.11.0
+version: 0.12.0
 appVersion: v0.14.0
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -162,8 +162,7 @@ jaeger:
   # for example, you need to run 'helm install --set jaeger.url=myurl ...'
   url: "SET THIS ON THE COMMAND LINE"
 
-sshGitServers:
-  {}
+sshGitServers: []
   ## Private git servers over ssh
   ## to enable uncomment lines with single hash below
   ## hostname of the git server


### PR DESCRIPTION
sshGitServers is a list not a dict, so the default value shouldn't be a dictionary.