### PR TITLE
fix label overriding on service monitor

### DIFF
--- a/charts/athens-proxy/templates/service-monitor.yaml
+++ b/charts/athens-proxy/templates/service-monitor.yaml
@@ -4,8 +4,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "athens.metaLabels" . | nindent 4 }}
-    prometheus: default
+    {{- $metaLabels := include "athens.metaLabels" . | fromYaml }}
+    {{- $userLabels := .Values.metrics.serviceMonitor.labels | default dict }}
+    {{- $mergedLabels := merge $userLabels $metaLabels }}
+    {{- range $key, $value := $mergedLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
Currently, when we define label under `metrics.serviceMonitor.labels` it won't work. This PR will fix this issue.