### PR TITLE
Fix kubeVersion in Chart.yaml to support EKS and other 'non-standard' K8S versions

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: athens-proxy
 version: 0.14.0
 appVersion: v0.15.1
-kubeVersion: ">= 1.19"
+kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png
 keywords:


### PR DESCRIPTION


Currently `kubeVersion` is only allowing standard semver compatible versions like `v1.29.11` for example. In many cases however, such as when running on EKS, you'll have a version like `v1.28.5-eks-5e0fdde` which when run with `helm template --validate` produces an error:

```
$ helm template athens athens/athens-proxy --version ~0.14.0 --namespace athens --values values.yaml --validate --is-upgrade
Error: chart requires kubeVersion: >= 1.19 which is incompatible with Kubernetes v1.28.5-eks-5e0fdde
```

This change should fix the issue by opening up the version constraint slightly to support 'pre-release' versions as suggested here:
- https://github.com/helm/helm/issues/10375#issuecomment-974203557 (suggested change)
- https://github.com/helm/helm/issues/10375#issuecomment-986496851 (EKS's response for the curious)
- https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions