### PR TITLE
Bump chart version

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.14.1
-appVersion: v0.15.1
+version: 0.14.2
+appVersion: v0.15.2
 kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules
 icon: https://raw.githubusercontent.com/gomods/athens/main/docs/static/banner.png


### PR DESCRIPTION
# Description

This bumps the chart version with the latest app version so that we can start using go1.22