### PR TITLE
Allow configuring readiness probe through values

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.14.3
+version: 0.14.4
 appVersion: v0.15.4
 kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -90,9 +90,13 @@ spec:
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           httpGet:
             path: "/readyz"
             port: 3000
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         env:
         - name: ATHENS_GOGET_WORKERS
           value: {{ .Values.goGetWorkers | quote }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -21,6 +21,12 @@ livenessProbe:
   successThreshold: 1
   timeoutSeconds: 1
 
+readinessProbe:
+  failureThreshold: 3
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+
 strategy:
   # -- Using RollingUpdate requires a shared storage
   type: Recreate


### PR DESCRIPTION
Use readiness probe parameters from values.
In some cases it's required to adjust the default probe parameters and currently this is only possible for the liveness probe.