### PR TITLE
Addition of configurable init containers to athens-proxy

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.14.5
+version: 0.14.6
 appVersion: v0.16.0
 kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -71,8 +71,9 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | ingress.enabled | bool | `false` | Create an Ingress resource for athens |
 | ingress.hosts | list | `[]` | Provide an array of values for the ingress host mapping |
 | ingress.tls | list | `[]` |  |
+| initContainerResources | object | `{}` | sshGitServers init container resources |
 | initContainerSecurityContext | object | `{}` | sshGitServers init container security context configuration |
-| intiContainerResources | object | `{}` | sshGitServers init container resources |
+| intiContainerResources | object | `{}` | sshGitServers init container resources (deprecated naming, if initContainerResources is defined, that will be used in preference to this value) |
 | jaeger.annotations | object | `{}` |  |
 | jaeger.enabled | bool | `false` | Deploy a jaeger "all-in-one" pod for tracing |
 | jaeger.image.repository | string | `"jaegertracing/all-in-one"` |  |

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -1,6 +1,6 @@
 # Athens Proxy Helm Chart: athens-proxy
 
-![Version: 0.14.5](https://img.shields.io/badge/Version-0.14.5-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
+![Version: 0.14.6](https://img.shields.io/badge/Version-0.14.6-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
 
 ## What is Athens?
 
@@ -53,6 +53,7 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | basicAuth.secretName | string | `"athens-proxy-basic-auth"` | Secret name, containing the 'passwordSecretKey' and 'usernameSecretKey' |
 | basicAuth.usernameSecretKey | string | `"username"` |  |
 | configEnvVars | list | `[]` | Set environment variables to be passed to athens pods |
+| extraInitContainers | list | `[]` | Define extra init containers for athens-proxy |
 | extraLabels | object | `{}` | Add extra labels to all resources |
 | extraVolumeMounts | object | `{}` | Add extra volume mounts to deployment pod primary container |
 | extraVolumes | object | `{}` | Add extra volumes to deployment pod |
@@ -70,8 +71,8 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | ingress.enabled | bool | `false` | Create an Ingress resource for athens |
 | ingress.hosts | list | `[]` | Provide an array of values for the ingress host mapping |
 | ingress.tls | list | `[]` |  |
-| initContainerSecurityContext | object | `{}` | Init container security context configuration |
-| intiContainerResources | object | `{}` | Define resources for the init container of athens |
+| initContainerSecurityContext | object | `{}` | sshGitServers init container security context configuration |
+| intiContainerResources | object | `{}` | sshGitServers init container resources |
 | jaeger.annotations | object | `{}` |  |
 | jaeger.enabled | bool | `false` | Deploy a jaeger "all-in-one" pod for tracing |
 | jaeger.image.repository | string | `"jaegertracing/all-in-one"` |  |

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.intiContainerResources }}
+          {{- with (default .Values.intiContainerResources .Values.initContainerResources) }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -45,8 +45,9 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.image.pullSecrets | nindent 8 }}
       {{- end }}
-      {{- if .Values.sshGitServers }}
+      {{- if or .Values.sshGitServers .Values.extraInitContainers }}
       initContainers:
+      {{- if .Values.sshGitServers }}
         - name: copy-key-files
           image: alpine:3.9
           command:
@@ -76,6 +77,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- end }}
+      {{- if .Values.extraInitContainers }}
+        {{- toYaml .Values.extraInitContainers | nindent 6 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: {{ include "fullname" . }}
@@ -216,7 +221,7 @@ spec:
         {{- end }}
         ports:
         - containerPort: 3000
-        {{- if or (eq .Values.storage.type "disk") .Values.upstreamProxy.enabled .Values.netrc.enabled .Values.sshGitServers .Values.gitconfig.enabled}}
+        {{- if or (eq .Values.storage.type "disk") .Values.upstreamProxy.enabled .Values.netrc.enabled .Values.sshGitServers .Values.gitconfig.enabled .Values.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if eq .Values.storage.type "disk" }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -206,14 +206,23 @@ initContainerSecurityContext: {}
   # allowPrivilegeEscalation: false
   # runAsNonRoot: true
 
-# -- sshGitServers init container resources
+# -- sshGitServers init container resources (deprecated naming, if initContainerResources is defined, that will be used in preference to this value)
 intiContainerResources: {}
-#  limits:
-#    cpu: 100m
-#    memory: 64Mi
-#  requests:
-#    cpu: 100m
-#    memory: 64Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 64Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 64Mi
+
+# -- sshGitServers init container resources
+initContainerResources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 64Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 64Mi
 
 # -- Define extra init containers for athens-proxy
 extraInitContainers: []

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -115,11 +115,6 @@ securityContext: {}
   # allowPrivilegeEscalation: false
   # runAsNonRoot: true
 
-# -- Init container security context configuration
-initContainerSecurityContext: {}
-  # allowPrivilegeEscalation: false
-  # runAsNonRoot: true
-
 # -- Set environment variables to be passed to athens pods
 configEnvVars: []
 
@@ -206,6 +201,26 @@ sshGitServers: []
   #     name: ssh-keys
   #     subPath: secret.id_rsa
 
+# -- sshGitServers init container security context configuration
+initContainerSecurityContext: {}
+  # allowPrivilegeEscalation: false
+  # runAsNonRoot: true
+
+# -- sshGitServers init container resources
+intiContainerResources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 64Mi
+#  requests:
+#    cpu: 100m
+#    memory: 64Mi
+
+# -- Define extra init containers for athens-proxy
+extraInitContainers: []
+  # - name: init
+  #   image: busybox:1.28
+  #   command: ['sh', '-c', "echo 'hello world'"]
+
 # -- Specify the number of go workers
 goGetWorkers: 3
 
@@ -252,16 +267,6 @@ resources: {}
 #  requests:
 #    cpu: 100m
 #    memory: 64Mi
-
-# -- Define resources for the init container of athens
-intiContainerResources: {}
-#  limits:
-#    cpu: 100m
-#    memory: 64Mi
-#  requests:
-#    cpu: 100m
-#    memory: 64Mi
-
 
 # -- Set the number of athens-proxy replicas, unless autoscaling is enabled
 replicaCount: 1


### PR DESCRIPTION
Resolves issue #106

This adds the ability to add extra init containers to the athens proxy. I'm using a credentials-helper to provide authentication to the git repositories for athens. Using an init container can ensure the volumes are set up correctly.

Also adding clarification to the existing initContainer configuration 'initContainerSecurityContext' and 'intiContainerResources' to indicate they only apply to the 'sshGitServer' init container.