### PR TITLE
allow setting lifecycle hook and terminationGracePeriodSeconds

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.14.6
+version: 0.14.7
 appVersion: v0.16.0
 kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -80,6 +80,7 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | jaeger.image.tag | string | `"latest"` |  |
 | jaeger.type | string | `"ClusterIP"` | Type of service; valid values are "ClusterIP", "LoadBalancer", and "NodePort". |
 | jaeger.url | string | `""` | Specify the jaeger URL for the environment variable used by athens. With default settings, it uses the jaeger-collector-http port of the jaeger service. |
+| lifecycle | object | `{}` | Container lifecycle hooks configuration. see API reference: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/ |
 | livenessProbe.failureThreshold | int | `3` |  |
 | livenessProbe.periodSeconds | int | `10` |  |
 | livenessProbe.successThreshold | int | `1` |  |
@@ -126,6 +127,7 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | strategy.rollingUpdate.maxSurge | int | `1` |  |
 | strategy.rollingUpdate.maxUnavailable | int | `1` |  |
 | strategy.type | string | `"Recreate"` | Using RollingUpdate requires a shared storage |
+| terminationGracePeriodSeconds | int | `30` | see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#pod-v1-core. the default value is 30 seconds. |
 | tolerations | list | `[]` | see https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling |
 | tracing.enabled | bool | `false` | Set ATHENS_TRACE_EXPORTER* environment variables to point to a tracing deployment. |
 | tracing.type | string | `"jaeger"` | Value of ATHENS_TRACE_EXPORTER, supported values are "jaeger", "datadog", and "stackdriver". |

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -1,6 +1,6 @@
 # Athens Proxy Helm Chart: athens-proxy
 
-![Version: 0.14.6](https://img.shields.io/badge/Version-0.14.6-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
+![Version: 0.14.7](https://img.shields.io/badge/Version-0.14.7-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
 
 ## What is Athens?
 

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -28,4 +28,4 @@ terminationGracePeriodSeconds: 60
 lifecycle:
   preStop:
     exec:
-      command: [ "/bin/sleep", "10" ]
+      command: ["/bin/sleep", "10"]

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -24,3 +24,8 @@ jaeger:
     test.annotation: "jaeger"
 service:
   type: "NodePort"
+terminationGracePeriodSeconds: 60
+lifecycle:
+  preStop:
+    exec:
+      command: [ "/bin/sleep", "10" ]

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.image.runAsNonRoot }}
       securityContext:
         runAsUser: 1000
@@ -265,6 +268,10 @@ spec:
         {{- end }}
         {{- with .Values.securityContext }}
         securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.lifecycle }}
+        lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- with .Values.resources }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -108,12 +108,20 @@ storage:
 # see API reference: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 priorityClassName: ""
 
+# -- see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#pod-v1-core.
+# the default value is 30 seconds.
+terminationGracePeriodSeconds: 30
+
 # -- Container security context configuration.
 # see API reference: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core.
 # This will override the `image.runAsNonRoot` settings in the specified container if `runAsUser` or `runAsGroup` are set
 securityContext: {}
   # allowPrivilegeEscalation: false
   # runAsNonRoot: true
+
+# -- Container lifecycle hooks configuration.
+# see API reference: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle: {}
 
 # -- Set environment variables to be passed to athens pods
 configEnvVars: []


### PR DESCRIPTION
https://github.com/gomods/athens-charts/issues/108

Modify the athens-chart to provide an option to configure `lifecycle` hook and `terminationGracePeriodSeconds`. Set the default value of `terminationGracePeriodSeconds` to be 30 seconds as it's the default value in Kubernetes. 