### PR TITLE
Add options to set Athens single flight configs and create passwords in secrets.yml

### DIFF
--- a/charts/athens-proxy/Chart.yaml
+++ b/charts/athens-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: athens-proxy
-version: 0.14.7
+version: 0.14.8
 appVersion: v0.16.0
 kubeVersion: ">= 1.19-0"
 description: The proxy server for Go modules

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -1,6 +1,6 @@
 # Athens Proxy Helm Chart: athens-proxy
 
-![Version: 0.14.7](https://img.shields.io/badge/Version-0.14.7-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
+![Version: 0.14.8](https://img.shields.io/badge/Version-0.14.8-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
 
 ## What is Athens?
 
@@ -103,6 +103,17 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | service.type | string | `"ClusterIP"` | Type of service; valid values are "ClusterIP", "LoadBalancer", and "NodePort". "ClusterIP" is sufficient in the case when the Proxy will be used from within the cluster. To expose externally, consider a "NodePort" or "LoadBalancer" service or use an "Ingress". |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount |
+| singleFlight.etcd.endpoints | string | `""` |  |
+| singleFlight.redis.endpoint | string | `""` |  |
+| singleFlight.redis.lockConfig | object | `{}` |  |
+| singleFlight.redis.password | string | `""` |  |
+| singleFlight.redisSentinel.endpoints | string | `""` |  |
+| singleFlight.redisSentinel.lockConfig | object | `{}` |  |
+| singleFlight.redisSentinel.masterName | string | `""` |  |
+| singleFlight.redisSentinel.redisPassword | string | `""` |  |
+| singleFlight.redisSentinel.redisUsername | string | `""` |  |
+| singleFlight.redisSentinel.sentinelPassword | string | `""` |  |
+| singleFlight.type | string | `""` | SingleFlight type to use. Options are ["memory", "etcd", "redis", "redis-sentinel", "gcp", "azureblob"]. Default option is "memory" if type is not set. |
 | sshGitServers | list | `[]` | Configuration for private git servers that will provide ssh and git config to athens in a ConfigMap |
 | storage.disk.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | storage.disk.persistence.enabled | bool | `false` | Note if you use disk.persistence.enabled, replicaCount should be set to 1 unless your access mode is 'ReadWriteMany' and strategy type must be 'Recreate' |

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -113,7 +113,7 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | singleFlight.redisSentinel.redisPassword | string | `""` |  |
 | singleFlight.redisSentinel.redisUsername | string | `""` |  |
 | singleFlight.redisSentinel.sentinelPassword | string | `""` |  |
-| singleFlight.type | string | `""` | SingleFlight type to use. Options are ["memory", "etcd", "redis", "redis-sentinel", "gcp", "azureblob"]. Default option is "memory" if type is not set. |
+| singleFlight.type | string | `""` | SingleFlight type to use. Options are ["memory", "etcd", "redis", "redis-sentinel", "gcp", "azureblob"]. see https://docs.gomods.io/configuration/storage/#running-multiple-athens-pointed-at-the-same-storage |
 | sshGitServers | list | `[]` | Configuration for private git servers that will provide ssh and git config to athens in a ConfigMap |
 | storage.disk.persistence.accessMode | string | `"ReadWriteOnce"` |  |
 | storage.disk.persistence.enabled | bool | `false` | Note if you use disk.persistence.enabled, replicaCount should be set to 1 unless your access mode is 'ReadWriteMany' and strategy type must be 'Recreate' |

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -29,10 +29,3 @@ lifecycle:
   preStop:
     exec:
       command: ["/bin/sleep", "10"]
-singleFlight:
-  type: "redis"
-  redis:
-    endpoint: "host:6379"
-    password: "123456"
-    lockConfig:
-      ttl: 900

--- a/charts/athens-proxy/ci/basic-values.yaml
+++ b/charts/athens-proxy/ci/basic-values.yaml
@@ -29,3 +29,10 @@ lifecycle:
   preStop:
     exec:
       command: ["/bin/sleep", "10"]
+singleFlight:
+  type: "redis"
+  redis:
+    endpoint: "host:6379"
+    password: "123456"
+    lockConfig:
+      ttl: 900

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -188,6 +188,83 @@ spec:
           value: {{ .Values.storage.minio.bucket | quote }}
         {{- end }}
 {{- end }}
+        {{- if .Values.singleFlight.type }}
+        - name: ATHENS_SINGLE_FLIGHT_TYPE
+          value: {{ .Values.singleFlight.type | quote }}
+        {{- end }}
+{{- if eq .Values.singleFlight.type "etcd"}}
+        {{- if .Values.singleFlight.etcd.endpoints }}
+        - name: ATHENS_ETCD_ENDPOINTS
+          value: {{ .Values.singleFlight.etcd.endpoints | quote }}
+        {{- end }}
+{{- else if eq .Values.singleFlight.type "redis"}}
+        {{- if .Values.singleFlight.redis.endpoint }}
+        - name: ATHENS_REDIS_ENDPOINT
+          value: {{ .Values.singleFlight.redis.endpoint | quote }}
+        {{- end }}
+        {{- if .Values.singleFlight.redis.password }}
+        - name: ATHENS_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . }}-secret
+              key: ATHENS_SINGLE_FLIGHT_REDIS_PASSWORD
+        {{- end }}
+        {{- with .Values.singleFlight.redis.lockConfig }}
+        {{- if .ttl }}
+        - name: ATHENS_REDIS_LOCK_TTL
+          value: {{ .ttl | quote }}
+        {{- end }}
+        {{- if .timeout }}
+        - name: ATHENS_REDIS_LOCK_TIMEOUT
+          value: {{ .timeout | quote }}
+        {{- end }}
+        {{- if .maxRetries }}
+        - name: ATHENS_REDIS_LOCK_MAX_RETRIES
+          value: {{ .maxRetries | quote }}
+        {{- end }}
+        {{- end }}
+{{- else if eq .Values.singleFlight.type "redis-sentinel"}}
+        {{- if .Values.singleFlight.redisSentinel.endpoints }}
+        - name: ATHENS_REDIS_SENTINEL_ENDPOINTS
+          value: {{ .Values.singleFlight.redisSentinel.endpoints | quote }}
+        {{- end }}
+        {{- if .Values.singleFlight.redisSentinel.masterName }}
+        - name: ATHENS_REDIS_SENTINEL_MASTER_NAME
+          value: {{ .Values.singleFlight.redisSentinel.masterName | quote }}
+        {{- end }}
+        {{- if .Values.singleFlight.redisSentinel.sentinelPassword }}
+        - name: ATHENS_REDIS_SENTINEL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . }}-secret
+              key: ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_SENTINEL_PASSWORD
+        {{- end }}
+        {{- if .Values.singleFlight.redisSentinel.redisUsername }}
+        - name: ATHENS_REDIS_USERNAME
+          value: {{ .Values.singleFlight.redisSentinel.redisUsername | quote }}
+        {{- end }}
+        {{- if .Values.singleFlight.redisSentinel.redisPassword }}
+        - name: ATHENS_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . }}-secret
+              key: ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_REDIS_PASSWORD
+        {{- end }}
+        {{- with .Values.singleFlight.redisSentinel.lockConfig }}
+        {{- if .ttl }}
+        - name: ATHENS_REDIS_LOCK_TTL
+          value: {{ .ttl | quote }}
+        {{- end }}
+        {{- if .timeout }}
+        - name: ATHENS_REDIS_LOCK_TIMEOUT
+          value: {{ .timeout | quote }}
+        {{- end }}
+        {{- if .maxRetries }}
+        - name: ATHENS_REDIS_LOCK_MAX_RETRIES
+          value: {{ .maxRetries | quote }}
+        {{- end }}
+        {{- end }}
+{{- end }}
         {{- if .Values.netrc.enabled }}
         - name: ATHENS_NETRC_PATH
           value: "/etc/netrc/.netrc"

--- a/charts/athens-proxy/templates/secret.yaml
+++ b/charts/athens-proxy/templates/secret.yaml
@@ -27,3 +27,12 @@ data:
   {{- if .Values.storage.minio.secretKey }}
   ATHENS_MINIO_SECRET_ACCESS_KEY: {{ .Values.storage.minio.secretKey | b64enc | quote }}
   {{- end }}
+  {{- if .Values.singleFlight.redis.password }}
+  ATHENS_SINGLE_FLIGHT_REDIS_PASSWORD: {{ .Values.singleFlight.redis.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.singleFlight.redisSentinel.sentinelPassword }}
+  ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_SENTINEL_PASSWORD: {{ .Values.singleFlight.redisSentinel.sentinelPassword | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.singleFlight.redisSentinel.redisPassword }}
+  ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_REDIS_PASSWORD: {{ .Values.singleFlight.redisSentinel.redisPassword | b64enc | quote }}
+  {{- end }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -107,7 +107,7 @@ storage:
 singleFlight:
   # -- SingleFlight type to use.
   # Options are ["memory", "etcd", "redis", "redis-sentinel", "gcp", "azureblob"].
-  # Default option is "memory" if type is not set.
+  # see https://docs.gomods.io/configuration/storage/#running-multiple-athens-pointed-at-the-same-storage
   type: ""
   etcd:
     endpoints: ""

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -104,6 +104,31 @@ storage:
     # as GCP figures out internal authentication between products for you.
     serviceAccount: ""
 
+singleFlight:
+  # -- SingleFlight type to use.
+  # Options are ["memory", "etcd", "redis", "redis-sentinel", "gcp", "azureblob"].
+  # Default option is "memory" if type is not set.
+  type: ""
+  etcd:
+    endpoints: ""
+  redis:
+    endpoint: ""
+    password: ""
+    lockConfig: {}
+    # ttl: 900
+    # timeout: 15
+    # maxRetries: 10
+  redisSentinel:
+    endpoints: ""
+    masterName: ""
+    sentinelPassword: ""
+    redisUsername: ""
+    redisPassword: ""
+    lockConfig: {}
+    # ttl: 900
+    # timeout: 15
+    # maxRetries: 10
+
 # -- Priority class for pod scheduling.
 # see API reference: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 priorityClassName: ""


### PR DESCRIPTION
https://github.com/gomods/athens-charts/issues/111

Provide options to set Athens single flight configurations in the helm chart and store redis passwords as secrets. 

Bump the chart version to 0.14.8.
