### PR TITLE
feat: add existingSecret support for Redis password in singleflight config

### DIFF
--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -107,10 +107,16 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount |
 | singleFlight.etcd.endpoints | string | `""` |  |
+| singleFlight.redis.database | int | `0` | Database index to use (0-15). Defaults to 0. |
 | singleFlight.redis.endpoint | string | `""` |  |
+| singleFlight.redis.existingSecret | string | `""` | Name of an existing Kubernetes Secret containing the Redis password. If set, the inline `password` value is ignored. The secret must contain a key matching `existingSecretKey`. |
+| singleFlight.redis.existingSecretKey | string | `"ATHENS_REDIS_PASSWORD"` | Key within the existing secret that holds the Redis password. |
 | singleFlight.redis.lockConfig | object | `{}` |  |
 | singleFlight.redis.password | string | `""` |  |
+| singleFlight.redisSentinel.database | int | `0` | Database index to use (0-15). Defaults to 0. |
 | singleFlight.redisSentinel.endpoints | string | `""` |  |
+| singleFlight.redisSentinel.existingSecret | string | `""` | Name of an existing Kubernetes Secret containing the sentinel password. If set, the inline `sentinelPassword` value is ignored. |
+| singleFlight.redisSentinel.existingSecretKey | string | `"ATHENS_REDIS_SENTINEL_PASSWORD"` | Key within the existing secret that holds the sentinel password. |
 | singleFlight.redisSentinel.lockConfig | object | `{}` |  |
 | singleFlight.redisSentinel.masterName | string | `""` |  |
 | singleFlight.redisSentinel.redisPassword | string | `""` |  |

--- a/charts/athens-proxy/README.md
+++ b/charts/athens-proxy/README.md
@@ -107,13 +107,11 @@ This will deploy a single Athens instance in the `athens` namespace with `disk` 
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Create a ServiceAccount |
 | singleFlight.etcd.endpoints | string | `""` |  |
-| singleFlight.redis.database | int | `0` | Database index to use (0-15). Defaults to 0. |
 | singleFlight.redis.endpoint | string | `""` |  |
 | singleFlight.redis.existingSecret | string | `""` | Name of an existing Kubernetes Secret containing the Redis password. If set, the inline `password` value is ignored. The secret must contain a key matching `existingSecretKey`. |
 | singleFlight.redis.existingSecretKey | string | `"ATHENS_REDIS_PASSWORD"` | Key within the existing secret that holds the Redis password. |
 | singleFlight.redis.lockConfig | object | `{}` |  |
 | singleFlight.redis.password | string | `""` |  |
-| singleFlight.redisSentinel.database | int | `0` | Database index to use (0-15). Defaults to 0. |
 | singleFlight.redisSentinel.endpoints | string | `""` |  |
 | singleFlight.redisSentinel.existingSecret | string | `""` | Name of an existing Kubernetes Secret containing the sentinel password. If set, the inline `sentinelPassword` value is ignored. |
 | singleFlight.redisSentinel.existingSecretKey | string | `"ATHENS_REDIS_SENTINEL_PASSWORD"` | Key within the existing secret that holds the sentinel password. |

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -212,10 +212,6 @@ spec:
               name: {{ include "fullname" . }}-secret
               key: ATHENS_SINGLE_FLIGHT_REDIS_PASSWORD
         {{- end }}
-        {{- if .Values.singleFlight.redis.database }}
-        - name: ATHENS_REDIS_DB
-          value: {{ .Values.singleFlight.redis.database | quote }}
-        {{- end }}
         {{- with .Values.singleFlight.redis.lockConfig }}
         {{- if .ttl }}
         - name: ATHENS_REDIS_LOCK_TTL
@@ -262,10 +258,6 @@ spec:
             secretKeyRef:
               name: {{ include "fullname" . }}-secret
               key: ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_REDIS_PASSWORD
-        {{- end }}
-        {{- if .Values.singleFlight.redisSentinel.database }}
-        - name: ATHENS_REDIS_DB
-          value: {{ .Values.singleFlight.redisSentinel.database | quote }}
         {{- end }}
         {{- with .Values.singleFlight.redisSentinel.lockConfig }}
         {{- if .ttl }}

--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -199,12 +199,22 @@ spec:
         - name: ATHENS_REDIS_ENDPOINT
           value: {{ .Values.singleFlight.redis.endpoint | quote }}
         {{- end }}
-        {{- if .Values.singleFlight.redis.password }}
+        {{- if .Values.singleFlight.redis.existingSecret }}
+        - name: ATHENS_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.singleFlight.redis.existingSecret | quote }}
+              key: {{ .Values.singleFlight.redis.existingSecretKey | quote }}
+        {{- else if .Values.singleFlight.redis.password }}
         - name: ATHENS_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ include "fullname" . }}-secret
               key: ATHENS_SINGLE_FLIGHT_REDIS_PASSWORD
+        {{- end }}
+        {{- if .Values.singleFlight.redis.database }}
+        - name: ATHENS_REDIS_DB
+          value: {{ .Values.singleFlight.redis.database | quote }}
         {{- end }}
         {{- with .Values.singleFlight.redis.lockConfig }}
         {{- if .ttl }}
@@ -229,7 +239,13 @@ spec:
         - name: ATHENS_REDIS_SENTINEL_MASTER_NAME
           value: {{ .Values.singleFlight.redisSentinel.masterName | quote }}
         {{- end }}
-        {{- if .Values.singleFlight.redisSentinel.sentinelPassword }}
+        {{- if .Values.singleFlight.redisSentinel.existingSecret }}
+        - name: ATHENS_REDIS_SENTINEL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.singleFlight.redisSentinel.existingSecret | quote }}
+              key: {{ .Values.singleFlight.redisSentinel.existingSecretKey | quote }}
+        {{- else if .Values.singleFlight.redisSentinel.sentinelPassword }}
         - name: ATHENS_REDIS_SENTINEL_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -246,6 +262,10 @@ spec:
             secretKeyRef:
               name: {{ include "fullname" . }}-secret
               key: ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_REDIS_PASSWORD
+        {{- end }}
+        {{- if .Values.singleFlight.redisSentinel.database }}
+        - name: ATHENS_REDIS_DB
+          value: {{ .Values.singleFlight.redisSentinel.database | quote }}
         {{- end }}
         {{- with .Values.singleFlight.redisSentinel.lockConfig }}
         {{- if .ttl }}

--- a/charts/athens-proxy/templates/secret.yaml
+++ b/charts/athens-proxy/templates/secret.yaml
@@ -27,10 +27,10 @@ data:
   {{- if .Values.storage.minio.secretKey }}
   ATHENS_MINIO_SECRET_ACCESS_KEY: {{ .Values.storage.minio.secretKey | b64enc | quote }}
   {{- end }}
-  {{- if .Values.singleFlight.redis.password }}
+  {{- if and .Values.singleFlight.redis.password (not .Values.singleFlight.redis.existingSecret) }}
   ATHENS_SINGLE_FLIGHT_REDIS_PASSWORD: {{ .Values.singleFlight.redis.password | b64enc | quote }}
   {{- end }}
-  {{- if .Values.singleFlight.redisSentinel.sentinelPassword }}
+  {{- if and .Values.singleFlight.redisSentinel.sentinelPassword (not .Values.singleFlight.redisSentinel.existingSecret) }}
   ATHENS_SINGLE_FLIGHT_REDIS_SENTINEL_SENTINEL_PASSWORD: {{ .Values.singleFlight.redisSentinel.sentinelPassword | b64enc | quote }}
   {{- end }}
   {{- if .Values.singleFlight.redisSentinel.redisPassword }}

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -114,6 +114,14 @@ singleFlight:
   redis:
     endpoint: ""
     password: ""
+    # -- Database index to use (0-15). Defaults to 0.
+    database: 0
+    # -- Name of an existing Kubernetes Secret containing the Redis password.
+    # If set, the inline `password` value is ignored.
+    # The secret must contain a key matching `existingSecretKey`.
+    existingSecret: ""
+    # -- Key within the existing secret that holds the Redis password.
+    existingSecretKey: "ATHENS_REDIS_PASSWORD"
     lockConfig: {}
     # ttl: 900
     # timeout: 15
@@ -124,6 +132,13 @@ singleFlight:
     sentinelPassword: ""
     redisUsername: ""
     redisPassword: ""
+    # -- Database index to use (0-15). Defaults to 0.
+    database: 0
+    # -- Name of an existing Kubernetes Secret containing the sentinel password.
+    # If set, the inline `sentinelPassword` value is ignored.
+    existingSecret: ""
+    # -- Key within the existing secret that holds the sentinel password.
+    existingSecretKey: "ATHENS_REDIS_SENTINEL_PASSWORD"
     lockConfig: {}
     # ttl: 900
     # timeout: 15

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -114,8 +114,6 @@ singleFlight:
   redis:
     endpoint: ""
     password: ""
-    # -- Database index to use (0-15). Defaults to 0.
-    database: 0
     # -- Name of an existing Kubernetes Secret containing the Redis password.
     # If set, the inline `password` value is ignored.
     # The secret must contain a key matching `existingSecretKey`.
@@ -132,8 +130,6 @@ singleFlight:
     sentinelPassword: ""
     redisUsername: ""
     redisPassword: ""
-    # -- Database index to use (0-15). Defaults to 0.
-    database: 0
     # -- Name of an existing Kubernetes Secret containing the sentinel password.
     # If set, the inline `sentinelPassword` value is ignored.
     existingSecret: ""


### PR DESCRIPTION
Closes #122

Adds `existingSecret` and `existingSecretKey` fields to the Redis and Redis Sentinel singleflight config, so users can reference an externally-managed Kubernetes secret instead of putting passwords inline in values.yaml. Works with External Secrets Operator, Sealed Secrets, etc.

Changes:
- `values.yaml`: new `existingSecret` and `existingSecretKey` fields for both `redis` and `redisSentinel`
- `deployment.yaml`: conditional secretKeyRef logic to use either the existing secret or the chart-generated one
- `secret.yaml`: skip writing inline password when existingSecret is set
- `README.md`: regenerated via helm-docs

hey @DrPsychick sorry for the long delay on this, it's a fairly small change overall. how does this look?